### PR TITLE
[FEATURE] Add audit logging functionality (#771)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 - master
   - New
+    - Added audit logging functionality
   - Changed
     - Fix a bug in autocalibration strategy merging, when two files have the same strategy key
     - Fix panic when setting rate to 0 in the interactive console

--- a/help.go
+++ b/help.go
@@ -96,7 +96,7 @@ func Usage() {
 		Description:   "Options for output. Output file formats, file names and debug file locations.",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"debug-log", "o", "of", "od", "or"},
+		ExpectedFlags: []string{"audit-log", "debug-log", "o", "of", "od", "or"},
 	}
 	sections := []UsageSection{u_http, u_general, u_compat, u_matcher, u_filter, u_input, u_output}
 

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -5,6 +5,7 @@ import (
 )
 
 type Config struct {
+	AuditLog                  string                `json:"auditlog"`
 	AutoCalibration           bool                  `json:"autocalibration"`
 	AutoCalibrationKeyword    string                `json:"autocalibration_keyword"`
 	AutoCalibrationPerHost    bool                  `json:"autocalibration_perhost"`

--- a/pkg/ffuf/configmarshaller.go
+++ b/pkg/ffuf/configmarshaller.go
@@ -74,6 +74,7 @@ func (c *Config) ToOptions() ConfigOptions {
 	o.Input.RequestProto = c.RequestProto
 	o.Input.Wordlists = c.Wordlists
 
+	o.Output.AuditLog = c.AuditLog
 	o.Output.DebugLog = c.Debuglog
 	o.Output.OutputDirectory = c.OutputDirectory
 	o.Output.OutputFile = c.OutputFile

--- a/pkg/ffuf/interfaces.go
+++ b/pkg/ffuf/interfaces.go
@@ -79,6 +79,13 @@ type OutputProvider interface {
 	Cycle()
 }
 
+// AuditLogger is responsible for providing auditing output of every request/response
+// sent and recieved by FFUF
+type AuditLogger interface {
+	Close()
+	Write(data interface{}) error
+}
+
 type Scraper interface {
 	Execute(resp *Response, matched bool) []ScraperResult
 	AppendFromFile(path string) error

--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -13,6 +13,7 @@ import (
 
 // Job ties together Config, Runner, Input and Output
 type Job struct {
+	AuditLogger          AuditLogger
 	Config               *Config
 	ErrorMutex           sync.Mutex
 	Input                InputProvider
@@ -395,6 +396,8 @@ func (j *Job) ffufHash(pos int) []byte {
 func (j *Job) runTask(input map[string][]byte, position int, retried bool) {
 	basereq := j.queuejobs[j.queuepos-1].req
 	req, err := j.Runner.Prepare(input, &basereq)
+	req.Timestamp = time.Now()
+
 	req.Position = position
 	if err != nil {
 		j.Output.Error(fmt.Sprintf("Encountered an error while preparing request: %s\n", err))
@@ -404,6 +407,18 @@ func (j *Job) runTask(input map[string][]byte, position int, retried bool) {
 	}
 
 	resp, err := j.Runner.Execute(&req)
+	if err != nil {
+		req.Error = err.Error()
+	}
+
+	// Audit the request after sending to the runner so we get any changes
+	if j.AuditLogger != nil {
+		e := j.AuditLogger.Write(&req)
+		if e != nil {
+			j.Output.Error(fmt.Sprintf("Encountered error while writing request audit log: %s\n", e))
+		}
+	}
+
 	if err != nil {
 		if retried {
 			j.incError()
@@ -435,6 +450,15 @@ func (j *Job) runTask(input map[string][]byte, position int, retried bool) {
 		}
 		return
 	}
+
+	// audit the response after the error handling
+	if j.AuditLogger != nil {
+		err = j.AuditLogger.Write(&resp)
+		if err != nil {
+			j.Output.Error(fmt.Sprintf("Encountered error while writing response audit log: %s\n", err))
+		}
+	}
+
 	if j.SpuriousErrorCounter > 0 {
 		j.resetSpuriousErrors()
 	}

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -87,6 +87,7 @@ type InputOptions struct {
 }
 
 type OutputOptions struct {
+	AuditLog            string `json:"audit_log"`
 	DebugLog            string `json:"debug_log"`
 	OutputDirectory     string `json:"output_directory"`
 	OutputFile          string `json:"output_file"`
@@ -173,6 +174,7 @@ func NewConfigOptions() *ConfigOptions {
 	c.Matcher.Status = "200-299,301,302,307,401,403,405,500"
 	c.Matcher.Time = ""
 	c.Matcher.Words = ""
+	c.Output.AuditLog = ""
 	c.Output.DebugLog = ""
 	c.Output.OutputDirectory = ""
 	c.Output.OutputFile = ""
@@ -512,6 +514,7 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 	conf.InputNum = parseOpts.Input.InputNum
 
 	conf.InputShell = parseOpts.Input.InputShell
+	conf.AuditLog = parseOpts.Output.AuditLog
 	conf.OutputFile = parseOpts.Output.OutputFile
 	conf.OutputDirectory = parseOpts.Output.OutputDirectory
 	conf.OutputSkipEmptyFile = parseOpts.Output.OutputSkipEmptyFile

--- a/pkg/ffuf/request.go
+++ b/pkg/ffuf/request.go
@@ -2,18 +2,21 @@ package ffuf
 
 import (
 	"strings"
+	"time"
 )
 
 // Request holds the meaningful data that is passed for runner for making the query
 type Request struct {
-	Method   string
-	Host     string
-	Url      string
-	Headers  map[string]string
-	Data     []byte
-	Input    map[string][]byte
-	Position int
-	Raw      string
+	Method    string
+	Host      string
+	Url       string
+	Headers   map[string]string
+	Data      []byte
+	Input     map[string][]byte
+	Position  int
+	Raw       string
+	Error     string
+	Timestamp time.Time
 }
 
 func NewRequest(conf *Config) Request {

--- a/pkg/ffuf/response.go
+++ b/pkg/ffuf/response.go
@@ -20,7 +20,8 @@ type Response struct {
 	Raw           string
 	ResultFile    string
 	ScraperData   map[string][]string
-	Time          time.Duration
+	Duration      time.Duration
+	Timestamp     time.Time
 }
 
 // GetRedirectLocation returns the redirect location for a 3xx redirect HTTP response

--- a/pkg/filter/time.go
+++ b/pkg/filter/time.go
@@ -44,12 +44,12 @@ func (f *TimeFilter) MarshalJSON() ([]byte, error) {
 
 func (f *TimeFilter) Filter(response *ffuf.Response) (bool, error) {
 	if f.gt {
-		if response.Time.Milliseconds() > f.ms {
+		if response.Duration.Milliseconds() > f.ms {
 			return true, nil
 		}
 
 	} else if f.lt {
-		if response.Time.Milliseconds() < f.ms {
+		if response.Duration.Milliseconds() < f.ms {
 			return true, nil
 		}
 	}

--- a/pkg/filter/time_test.go
+++ b/pkg/filter/time_test.go
@@ -43,8 +43,8 @@ func TestTimeFiltering(t *testing.T) {
 		{2, false},
 	} {
 		resp := ffuf.Response{
-			Data: []byte("dahhhhhtaaaaa"),
-			Time: time.Duration(test.input * int64(time.Millisecond)),
+			Data:     []byte("dahhhhhtaaaaa"),
+			Duration: time.Duration(test.input * int64(time.Millisecond)),
 		}
 		filterReturn, _ := f.Filter(&resp)
 		if filterReturn != test.output {

--- a/pkg/output/audit.go
+++ b/pkg/output/audit.go
@@ -1,0 +1,58 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"sync"
+)
+
+type AuditLogger struct {
+	file *os.File
+	lock sync.Mutex
+}
+
+func NewAuditLogger(filename string) (*AuditLogger, error) {
+	f, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+	auditLogger := &AuditLogger{file: f}
+
+	return auditLogger, nil
+}
+
+func (logger *AuditLogger) Close() {
+	logger.file.Close()
+}
+
+func (logger *AuditLogger) Write(data interface{}) error {
+	logger.lock.Lock()
+	defer logger.lock.Unlock()
+
+	d := struct {
+		Type string
+		Data interface{}
+	}{
+		reflect.TypeOf(data).String(),
+		data,
+	}
+
+	j, err := json.Marshal(d)
+	if err != nil {
+		return fmt.Errorf("could not marshal json data: %s", err)
+	}
+
+	_, err = logger.file.Write(j)
+	if err != nil {
+		return fmt.Errorf("could not write json data to audit log: %s", err)
+	}
+
+	_, err = logger.file.Write([]byte("\n"))
+	if err != nil {
+		return fmt.Errorf("could not write newline to underlying io.Writer: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/output/audit_test.go
+++ b/pkg/output/audit_test.go
@@ -1,0 +1,119 @@
+package output
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
+
+func TestAuditLogger(t *testing.T) {
+	file, _ := os.CreateTemp("", "prefix")
+	filename := file.Name()
+	file.Close()
+	audit, err := NewAuditLogger(filename)
+
+	if err != nil {
+		t.Errorf("Error creating audit logger: %s", err)
+	}
+
+	if audit == nil {
+		t.Errorf("Audit was nil, expected non-nil")
+	}
+
+	defer audit.Close()
+
+	err = os.Chmod(filename, 000)
+	if err != nil {
+		t.Errorf("Error executing Chmod: %s", err)
+	}
+
+	audit, err = NewAuditLogger(filename)
+
+	if err == nil {
+		t.Errorf("Error was nil, expected non-nil")
+	}
+
+	if audit != nil {
+		t.Errorf("Audit was non-nil, expected nil")
+	}
+
+	err = os.Chmod(filename, 6550)
+	if err != nil {
+		t.Errorf("Error executing Chmod: %s", err)
+	}
+
+	err = os.Remove(filename)
+	if err != nil {
+		t.Errorf("Error executing Remove: %s", err)
+	}
+
+}
+
+func TestAuditLogWrite(t *testing.T) {
+	expected := `{"Type":"ffuf.Config","Data":{"auditlog":"","autocalibration":false,"autocalibration_keyword":"","autocalibration_perhost":false,"autocalibration_strategies":null,"autocalibration_strings":null,"colors":false,"cmdline":"","configfile":"","postdata":"{\"quote\":\"I'll still be here tomorrow to high five you yesterday, my friend. Peace.\"}","debuglog":"","delay":{"Min":0,"Max":0,"IsRange":false,"HasDelay":false},"dirsearch_compatibility":false,"encoders":null,"extensions":null,"fmode":"","follow_redirects":false,"headers":{"Content-Type":"application/json","baz":"wibble","foo":"bar"},"ignorebody":false,"ignore_wordlist_comments":false,"inputmode":"","cmd_inputnum":0,"inputproviders":null,"inputshell":"","json":false,"matchers":null,"mmode":"","maxtime":0,"maxtime_job":0,"method":"POST","noninteractive":false,"outputdirectory":"","outputfile":"","outputformat":"","OutputSkipEmptyFile":false,"proxyurl":"","quiet":false,"rate":0,"raw":false,"recursion":false,"recursion_depth":0,"recursion_strategy":"","replayproxyurl":"","requestfile":"","requestproto":"","scraperfile":"","scrapers":"","sni":"","stop_403":false,"stop_all":false,"stop_errors":false,"threads":0,"timeout":0,"url":"http://example.com/aaaa","verbose":false,"wordlists":null,"http2":false,"client-cert":"","client-key":""}}
+{"Type":"ffuf.Request","Data":{"Method":"POST","Host":"","Url":"http://example.com/aaaa","Headers":{"Content-Type":"application/json","baz":"wibble","foo":"bar"},"Data":"eyJxdW90ZSI6IkknbGwgc3RpbGwgYmUgaGVyZSB0b21vcnJvdyB0byBoaWdoIGZpdmUgeW91IHllc3RlcmRheSwgbXkgZnJpZW5kLiBQZWFjZS4ifQ==","Input":null,"Position":0,"Raw":"","Error":"","Timestamp":"0001-01-01T00:00:00Z"}}
+`
+
+	headers := make(map[string]string)
+	headers["foo"] = "bar"
+	headers["baz"] = "wibble"
+	headers["Content-Type"] = "application/json"
+
+	data := "{\"quote\":\"I'll still be here tomorrow to high five you yesterday, my friend. Peace.\"}"
+
+	req := ffuf.Request{Method: "POST", Url: "http://example.com/aaaa", Headers: headers, Data: []byte(data)}
+	config := ffuf.Config{Method: "POST", Url: "http://example.com/aaaa", Headers: headers, Data: data}
+
+	file, _ := os.CreateTemp("", "prefix")
+	filename := file.Name()
+	file.Close()
+	audit, err := NewAuditLogger(filename)
+
+	if err != nil {
+		t.Errorf("Error creating audit logger: %s", err)
+	}
+
+	if audit == nil {
+		t.Errorf("Audit was nil, expected non-nil")
+	}
+
+	// test attempting to log a bung object and erroring
+	type A struct{ A *A } // cyclic struct to break JSON Marshalling
+	a := A{}
+	a.A = &a
+
+	err = audit.Write(a)
+	if err == nil {
+		t.Errorf("Error was nil, expected non-nil")
+	}
+
+	// test writing the config and request objects
+	err = audit.Write(config)
+	if err != nil {
+		t.Errorf("Error was not nil, expected nil")
+	}
+
+	err = audit.Write(req)
+	if err != nil {
+		t.Errorf("Error was not nil, expected nil")
+	}
+
+	audit.Close()
+
+	// re-read and check the audit log
+	f, err := os.ReadFile(filename)
+	if err != nil {
+		t.Errorf("Error reading audit log: %s", err)
+	}
+
+	if string(f) != expected {
+		t.Errorf("Audit write did not produce the expected logfile.")
+	}
+
+	// writing to a closed audit log should fail
+	err = audit.Write(config)
+	if err == nil {
+		t.Errorf("Error was nil, expected non-nil")
+	}
+}

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -334,7 +334,7 @@ func (s *Stdoutput) Result(resp ffuf.Response) {
 		RedirectLocation: resp.GetRedirectLocation(false),
 		ScraperData:      resp.ScraperData,
 		Url:              resp.Request.Url,
-		Duration:         resp.Time,
+		Duration:         resp.Duration,
 		ResultFile:       resp.ResultFile,
 		Host:             resp.Request.Host,
 	}


### PR DESCRIPTION
* Added audit log functionality

* remove redundant comments

* Add tests for audit log writing

* Fix comment, add error checking on config auditing

* Fix auditlog tests

* Update CHANGELOG.md

* Re-order request logging and log raw request/responses when auditing

* Remove header cannonicalization

* Add support for multiple headers with the same name

* Add payload/response delta output

* Added payload/response delta into file outputs

* Fix audit log tests

* Minimize CLI output - remove words and lines

* Implement responsestats array for summary output

* Fix help

* Add response timing chart

* Add checks to response stats generation

* Add statistics and timing line chart to the response summary

* Fix minimum content-length size reporting in the summary

* Add error check to HostURLFromRequest

* Fix audit log err overwriting

* Fix erroneous err variable overwrite

* Implement box plots for summary view

* Update README.md

* Add errors to Request objects for logging

* Fix audit logger error message

* Revert "Merge branch 'master' into auditlogging"

This reverts commit ee8be893726dc306ae4c13a88e840f42b8ca54ba, reversing changes made to ed58fb634e0dda6a5aa06f8bcc7984a3c71f9c4e.

# Description

Please add a short description of pull request contents.
If this PR addresses an existing issue, please add the issue number below.

Fixes: #(issue number)

## Additonally

- [ ] If this is the first time you are contributing to ffuf, add your name to `CONTRIBUTORS.md`. 
The file should be alphabetically ordered.
- [ ] Add a short description of the fix to `CHANGELOG.md`

Thanks for contributing to ffuf :)
